### PR TITLE
:quiet option for espeak-ruby

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,6 +29,7 @@ Currently only subset of espeak features is supported.
   :voice => 'en',   # use voice file of this name from espeak-data/voices
   :pitch => 50,     # pitch adjustment, 0 to 99
   :speed => 170     # speed in words per minute, 80 to 370
+  :quiet => true    # prevent espeak-ruby from printing to stdout. (default false)
 
 
 These are default values, and they can be easily overridden:

--- a/lib/espeak-ruby.rb
+++ b/lib/espeak-ruby.rb
@@ -11,6 +11,7 @@ module ESpeak
   #    :voice     - use voice file of this name from espeak-data/voices. ie 'en', 'de', ...
   #    :pitch     - pitch adjustment, 0 to 99
   #    :speed     - speed in words per minute, 80 to 370
+  #    :quiet     - remove printing to stdout. Affects only lame (default false) 
   #
   def espeak(filename, options)
     if execute_system_command(filename, prepare_options(options))
@@ -47,14 +48,14 @@ private
   end
 
   def execute_system_command(filename, options)
-    system([espeak_command(options), lame_command(filename)] * " | ")
+    system([espeak_command(options), lame_command(filename, options)] * " | ")
   end
 
   def espeak_command(options)
     %|espeak "#{options[:text]}" --stdout -v#{options[:voice]} -p#{options[:pitch]} -s#{options[:speed]}|
   end
 
-  def lame_command(filename)
-    "lame -V2 - #{filename}"
+  def lame_command(filename, options)
+    "lame -V2 - #{filename} #{'--quiet' if options[:quiet] == true}"
   end
 end


### PR DESCRIPTION
Hey 

Small change to espeak-ruby to enable the silencing of the lame output to stdout. 

This was interfering with test output as my test log was filled up with lame output =)

I would have added some tests, but the test suite doesn't seem to be running at all (tried under 1.9.3 and 1.8.7).

Can go back and add tests if you think that the test suite is working and you think this change needs it.

Thanks
Dave Smylie 
