### PR TITLE
Add bytes() function 

### DIFF
--- a/lib/espeak/speech.rb
+++ b/lib/espeak/speech.rb
@@ -29,10 +29,18 @@ module ESpeak
       system(espeak_command(command_options, "--stdout") + " | " + lame_command(filename, command_options))
     end
 
-    # Returns wav file bytes as a result of
+    # Returns mp3 file bytes as a result of
     # Text-To-Speech conversion.
     #
     def bytes()
+      stdout_str, stderr_str, process = Open3.capture3(espeak_command(command_options, "--stdout") + " | " + std_lame_command(command_options))
+      stdout_str
+    end
+
+    # Returns wav file bytes as a result of
+    # Text-To-Speech conversion.
+    #
+    def bytes_wav()
       stdout_str, stderr_str, process = Open3.capture3(espeak_command(command_options, "--stdout"))
       stdout_str
     end
@@ -63,6 +71,10 @@ module ESpeak
 
     def espeak_command(options, flags="")
       %|espeak "#{sanitized_text}" #{flags} -v#{options[:voice]} -p#{options[:pitch]} -s#{options[:speed]}|
+    end
+
+    def std_lame_command(options)
+      lame_command("-", options)
     end
 
     def lame_command(filename, options)

--- a/lib/espeak/speech.rb
+++ b/lib/espeak/speech.rb
@@ -1,3 +1,5 @@
+require 'open3.rb'
+
 module ESpeak
   class Speech
     attr_reader :options, :text
@@ -25,6 +27,14 @@ module ESpeak
     # 
     def save(filename)
       system(espeak_command(command_options, "--stdout") + " | " + lame_command(filename, command_options))
+    end
+
+    # Returns wav file bytes as a result of
+    # Text-To-Speech conversion.
+    #
+    def bytes()
+      stdout_str, stderr_str, process = Open3.capture3(espeak_command(command_options, "--stdout"))
+      stdout_str
     end
 
     # espeak dies handling some chars


### PR DESCRIPTION
For returning the bytes of the wav generated by ESpeak.

I tried to keep things inline with what you've already got, I don't know if this lib is still under development at all, but it still seems (in my experience so far) to work reliably with Ruby 2.2 and I needed a feature like this.