### PR TITLE
add :capital param for the -k flag in espeak to modulate pitch on cap…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then use it like this:
 # Speaks "YO!"
 speech = Speech.new("YO!")
 speech.speak # invokes espeak
-  
+
 # Creates hello-de.mp3 file
 speech = Speech.new("Hallo Welt", voice: "de")
 speech.save("hello-de.mp3") # invokes espeak + lame
@@ -36,19 +36,20 @@ speech.save("hello-de.mp3") # invokes espeak + lame
 # Lists voices
 Voice.all.map { |v| v.language } # ["af", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "en-sc", "en-uk", "en-uk-north", "en-uk-rp", "en-uk-wmids", "en-us", "en-wi", "eo", "es", "es-la", "fi", "fr", "fr-be", "grc", "hi", "hr", "hu", "hy", "hy", "id", "is", "it", "jbo", "ka", "kn", "ku", "la", "lv", "mk", "ml", "nci", "nl", "no", "pap", "pl", "pt", "pt-pt", "ro", "ru", "sk", "sq", "sr", "sv", "sw", "ta", "tr", "vi", "zh", "zh-yue"]
 
-# Find particular voice 
+# Find particular voice
 Voice.find_by_language('en') #<ESpeak::Voice:0x007fe1d3806be8 @language="en", @name="default", @gender="M", @file="default">
 ```
 
 Features
 --------
 
-Currently only subset of espeak features is supported. 
+Currently only subset of espeak features is supported.
 
 ```ruby
-:voice => 'en'    # use voice file of this name from espeak-data/voices
-:pitch => 50      # pitch adjustment, 0 to 99
-:speed => 170     # speed in words per minute, 80 to 370
+:voice   => 'en'    # use voice file of this name from espeak-data/voices
+:pitch   => 50      # pitch adjustment, 0 to 99
+:speed   => 170     # speed in words per minute, 80 to 370
+:capital => 170     # increase emphasis (pitch) of capitalized words, 1 to 40 (for natural sound, can go higher)
 ```
 
 These are default values, and they can be easily overridden:

--- a/lib/espeak/speech.rb
+++ b/lib/espeak/speech.rb
@@ -3,28 +3,30 @@ require 'open3.rb'
 module ESpeak
   class Speech
     attr_reader :options, :text
-  
+
     # filename - The file that will be generated
     # options  - Posible key, values
     #    :voice     - use voice file of this name from espeak-data/voices. ie 'en', 'de', ...
     #    :pitch     - pitch adjustment, 0 to 99
     #    :speed     - speed in words per minute, 80 to 370
-    #    :quiet     - remove printing to stdout. Affects only lame (default false) 
-    #    
+    #    :capital   - increase emphasis of capitalized letters by raising pitch by this amount
+    #                 no range given in man but good range is 10-40 to start
+    #    :quiet     - remove printing to stdout. Affects only lame (default false)
+    #
     def initialize(text, options={})
       @text = text
       @options = options
     end
 
-    # Speaks text 
-    # 
+    # Speaks text
+    #
     def speak
       system(espeak_command(command_options))
     end
 
-    # Generates mp3 file as a result of 
-    # Text-To-Speech conversion. 
-    # 
+    # Generates mp3 file as a result of
+    # Text-To-Speech conversion.
+    #
     def save(filename)
       system(espeak_command(command_options, "--stdout") + " | " + lame_command(filename, command_options))
     end
@@ -58,7 +60,7 @@ module ESpeak
       default_options.merge(symbolize_keys(options))
     end
 
-    # Although espeak itself has default options 
+    # Although espeak itself has default options
     # I'm defining them here for easier generating
     # command (with simple hash.merge)
     #
@@ -66,11 +68,12 @@ module ESpeak
       { :voice => 'en',
         :pitch => 50,
         :speed => 170,
+        :capital => 1,
         :quiet => true }
     end
 
     def espeak_command(options, flags="")
-      %|espeak "#{sanitized_text}" #{flags} -v#{options[:voice]} -p#{options[:pitch]} -s#{options[:speed]}|
+      %|espeak "#{sanitized_text}" #{flags} -v#{options[:voice]} -p#{options[:pitch]} -k#{options[:capital]} -s#{options[:speed]}|
     end
 
     def std_lame_command(options)


### PR DESCRIPTION
Hi - I modified to add a :capital param to go to the -k flag in espeak, seems useful for creating better prosody. Up to you if you want to include, if not I'll just work off my fork :)

