### PR TITLE
Add `:amplitude` option to `ESpeak::Speech` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ ESpeak::Voice.find_by_language('en') #<ESpeak::Voice:0x007fe1d3806be8 @language=
 Currently only subset of espeak features is supported.
 
 ```ruby
-:voice   => 'en'    # use voice file of this name from espeak-data/voices
-:pitch   => 50      # pitch adjustment, 0 to 99
-:speed   => 170     # speed in words per minute, 80 to 370
-:capital => 170     # increase emphasis (pitch) of capitalized words, 1 to 40 (for natural sound, can go higher)
+:voice     => 'en'    # use voice file of this name from espeak-data/voices
+:pitch     => 50      # pitch adjustment, 0 to 99
+:speed     => 170     # speed in words per minute, 80 to 370
+:capital   => 170     # increase emphasis (pitch) of capitalized words, 1 to 40 (for natural sound, can go higher)
+:amplitude => 150     # amplitude (volume) adjustment, 0 to 200
 ```
 
 These are default values, and they can be easily overridden:

--- a/lib/espeak/speech.rb
+++ b/lib/espeak/speech.rb
@@ -12,6 +12,7 @@ module ESpeak
     #    :speed     - speed in words per minute, 80 to 370
     #    :capital   - increase emphasis of capitalized letters by raising pitch by this amount
     #                 no range given in man but good range is 10-40 to start
+    #    :amplitude - amplitude adjustment, 0 to 200
     #    :quiet     - remove printing to stdout. Affects only lame (default false)
     #
     def initialize(text, options = {})
@@ -73,12 +74,13 @@ module ESpeak
         pitch: 50,
         speed: 170,
         capital: 1,
+        amplitude: 100,
         quiet: true }
     end
 
     def espeak_command(options, flags = '')
       ['espeak', @text.to_s, flags.to_s, "-v#{options[:voice]}", "-p#{options[:pitch]}", "-k#{options[:capital]}",
-       "-s#{options[:speed]}"]
+       "-s#{options[:speed]}", "-a#{options[:amplitude]}"]
     end
 
     def std_lame_command(options)


### PR DESCRIPTION
1. Added support for `espeak`'s amplitude option to `ESpeak::Speech` class.
2. Updated README.

Fixes #21.