### PR TITLE
Save bytes

### DIFF
--- a/lib/espeak/speech.rb
+++ b/lib/espeak/speech.rb
@@ -28,23 +28,11 @@ module ESpeak
 
     # Generates mp3 file as a result of
     # Text-To-Speech conversion.
+    #   this method takes an optional speech param (bytes to save)
+    #   can be used with the combined output of many text to speech conversions
     #
-    def save(filename)
-      speech = bytes_wav
-      res = IO.popen(lame_command(filename, command_options), 'r+') do |process|
-        process.write(speech)
-        process.close_write
-        process.read
-      end
-      res.to_s
-    end
-
-    # Generates mp3 file as a result of
-    # Text-To-Speech conversion.
-    # this method takes an additonal input of bytes to save
-    # can be used with the combined output of many text to speech conversions
-    #
-    def save_bytes(filename, speech)
+    def save(filename, speech = nil)
+      speech = bytes_wav if speech.nil?
       res = IO.popen(lame_command(filename, command_options), 'r+') do |process|
         process.write(speech)
         process.close_write

--- a/lib/espeak/speech.rb
+++ b/lib/espeak/speech.rb
@@ -39,6 +39,20 @@ module ESpeak
       res.to_s
     end
 
+    # Generates mp3 file as a result of
+    # Text-To-Speech conversion.
+    # this method takes an additonal input of bytes to save
+    # can be used with the combined output of many text to speech conversions
+    #
+    def save_bytes(filename, speech)
+      res = IO.popen(lame_command(filename, command_options), 'r+') do |process|
+        process.write(speech)
+        process.close_write
+        process.read
+      end
+      res.to_s
+    end
+
     # Returns mp3 file bytes as a result of
     # Text-To-Speech conversion.
     #

--- a/test/cases/speech_test.rb
+++ b/test/cases/speech_test.rb
@@ -13,4 +13,14 @@ class SpeechTest < Test::Unit::TestCase
     assert File.exist?('test/tmp/test.mp3'), 'Mp3 file not generated'
     FileUtils.rm_rf('test/tmp')
   end
+
+  def test_save_with_bytes
+    FileUtils.rm_rf('test/tmp')
+    FileUtils.mkdir_p('test/tmp')
+    bytes = Speech.new('Hello!').bytes_wav
+    assert Speech.new('').save('test/tmp/test_bytes.mp3', bytes)
+    assert File.exist?('test/tmp/test_bytes.mp3'), 'Mp3 file not generated'
+    FileUtils.rm_rf('test/tmp')
+  end
+
 end


### PR DESCRIPTION
figured out a way to solve the question I had in this issue: https://github.com/dejan/espeak-ruby/issues/25

idea here is you can create multiple Speech objects along the process and capture the bytes for each.. combine into one array and call save(filename, speech)..  (where speech is the combined bytes).. 